### PR TITLE
Add animation of logos to the last page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,22 @@
     <script src="https://code.jquery.com/jquery-3.5.0.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
+    <style>
+        .logo {
+            position: absolute;
+            width: 50px;
+            height: 50px;
+            animation: move 5s infinite;
+        }
+
+        @keyframes move {
+            0% { transform: translate(0, 0); }
+            25% { transform: translate(100px, 0); }
+            50% { transform: translate(100px, 100px); }
+            75% { transform: translate(0, 100px); }
+            100% { transform: translate(0, 0); }
+        }
+    </style>
 </head>
 <body>
     <h1>Dependabot, CodeQL, and Secret Scanning Demo</h1>
@@ -37,6 +53,23 @@
         // デモ用のシークレット一覧
         const PLACEHOLDER_GITHUB_TOKEN = "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";
 
+        // Function to animate logos
+        function animateLogos() {
+            var logos = document.querySelectorAll('.logo');
+            logos.forEach(function(logo) {
+                logo.style.top = Math.random() * window.innerHeight + 'px';
+                logo.style.left = Math.random() * window.innerWidth + 'px';
+            });
+        }
+
+        setInterval(animateLogos, 1000);
     </script>
+
+    <div class="logo" style="top: 50px; left: 50px;">
+        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Logo">
+    </div>
+    <div class="logo" style="top: 150px; left: 150px;">
+        <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" alt="Octocat">
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Add animation of GitHub logo and Octocat to the last page of the site.

* Add CSS styles to position the logos and animate them using keyframes.
* Add JavaScript function to handle the animation of the logos.
* Add two div elements with class "logo" containing the GitHub logo and Octocat images.
* Set interval to call the animateLogos function every second.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/moulongzhang/moulongzhang.github.io/pull/8?shareId=b6015b74-d352-4da8-a7b2-22d23a41ab52).